### PR TITLE
Add missing variable

### DIFF
--- a/lib/wca_i18n/yaml_to_enriched_ruby_hash.rb
+++ b/lib/wca_i18n/yaml_to_enriched_ruby_hash.rb
@@ -3,6 +3,7 @@ require "psych"
 module WcaI18n
   PLURALIZATION_KEYS = %w(zero one two few many other).freeze
   ORIGINAL_HASH_TAG = "#original_hash: ".freeze
+  SHOVEL = "<<".freeze
   TranslatedLeaf = Struct.new(:translated, :original_hash)
 
   # Re-implement some parts of the ToRuby emitter to inject our TranslatedLeaf where needs be


### PR DESCRIPTION
@gregorbg The website currently crashes [here](https://www.worldcubeassociation.org/translations/status) because the `SHOVEL` variable is not defined.

We should probably do a release of this gem asap to fix the website (fingers crossed tagging a release still uploads it).

(I checked the fix by making my local Gemfile points to my fork)